### PR TITLE
Feature/refactor test corpus access

### DIFF
--- a/check/magma/magma_check.c
+++ b/check/magma/magma_check.c
@@ -9,7 +9,7 @@
 
 int_t case_timeout = RUN_TEST_CASE_TIMEOUT;
 bool_t do_virus_check = true, do_tank_check = true, do_dspam_check = true, do_spf_check = true;
-chr_t *virus_check_data_path = NULL, *tank_check_data_path = NULL, *dspam_check_data_path = NULL, *barrister_unit_test = NULL;
+chr_t *barrister_unit_test = NULL;
 
 /**
  * @brief Enable the log so we can print status information. We're only concerned with whether the
@@ -188,27 +188,6 @@ int_t check_args_parse(int argc, char *argv[]) {
 			}
 
 		}
-		else if (!st_cmp_cs_eq(NULLER(argv[i]), PLACER("--virus-path", 12))) {
-
-			if (!(virus_check_data_path = check_next_opt(argv, &i, argc))) {
-				do_virus_check = false;
-			}
-
-		}
-		else if (!st_cmp_cs_eq(NULLER(argv[i]), PLACER("--tank-path", 11))) {
-
-			if (!(tank_check_data_path = check_next_opt(argv, &i, argc))) {
-				do_tank_check = false;
-			}
-
-		}
-		else if (!st_cmp_cs_eq(NULLER(argv[i]), PLACER("--dspam-path", 12))) {
-
-			if (!(dspam_check_data_path = check_next_opt(argv, &i, argc))) {
-				do_dspam_check = false;
-			}
-
-		}
 		else if (!st_cmp_cs_eq(NULLER(argv[i]), PLACER("--disable-spf", 13))) {
 			do_spf_check = false;
 			i++;
@@ -256,24 +235,10 @@ int main(int argc, char *argv[]) {
 	if ((result = check_args_parse(argc, argv)) != 1) {
 		exit(result ? EXIT_FAILURE : EXIT_SUCCESS);
 	}
-
-	if (do_virus_check && !virus_check_data_path) {
-		virus_check_data_path = ns_dupe(VIRUS_CHECK_DATA_PATH);
-	}
-
-	if (do_tank_check && !tank_check_data_path) {
-		tank_check_data_path = ns_dupe(TANK_CHECK_DATA_PATH);
-	}
-
-	if (do_dspam_check && !dspam_check_data_path) {
-		dspam_check_data_path = ns_dupe(DSPAM_CHECK_DATA_PATH);
-	}
-
 	if (!process_start()) {
 		log_error("Initialization error. Exiting.\n");
 		status_set(-1);
 		process_stop();
-		ns_cleanup( virus_check_data_path, tank_check_data_path, dspam_check_data_path);
 		exit(EXIT_FAILURE);
 	}
 	// Only during development...
@@ -343,7 +308,7 @@ int main(int argc, char *argv[]) {
 	// Cleanup and free the resources allocated by the magma code.
 	process_stop();
 
-	ns_cleanup(barrister_unit_test, virus_check_data_path, tank_check_data_path, dspam_check_data_path);
+	ns_cleanup(barrister_unit_test);
 	exit((failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE);
 
 }

--- a/check/magma/magma_check.h
+++ b/check/magma/magma_check.h
@@ -76,15 +76,11 @@ Suite * suite_check_sample(void);
 #define TANK_CHECK_DATA_UNUM 1L
 #define TANK_CHECK_DATA_MTHREADS 2 // Disabled
 #define TANK_CHECK_DATA_CLEANUP true
-#define TANK_CHECK_DATA_PATH "dev/corpus/"
 
 #define DSPAM_CHECK_SIZE_MIN 1024
 #define DSPAM_CHECK_SIZE_MAX (2 * 1024)
 #define DSPAM_CHECK_DATA_UNUM 1L
 #define DSPAM_CHECK_ITERATIONS 128
-#define DSPAM_CHECK_DATA_PATH "dev/corpus/"
-
-#define VIRUS_CHECK_DATA_PATH "dev/corpus/"
 
 // Controls the size of the compression test block.
 #define COMPRESS_CHECK_SIZE_MIN 1024 // 1 kilobyte
@@ -153,16 +149,12 @@ Suite * suite_check_sample(void);
 #define TANK_CHECK_DATA_UNUM 1L
 #define TANK_CHECK_DATA_MTHREADS 8
 #define TANK_CHECK_DATA_CLEANUP true
-#define TANK_CHECK_DATA_PATH "dev/corpus"
 
 #define DSPAM_CHECK_DATA_UNUM 1L
 #define DSPAM_CHECK_ITERATIONS 8192
 #define DSPAM_CHECK_SIZE_MIN 1024
 #define DSPAM_CHECK_SIZE_MAX (16 * 1024)
 //#define DSPAM_CHECK_SIZE_MAX (1 * 1024 * 1024) // 1 megabyte
-#define DSPAM_CHECK_DATA_PATH "dev/corpus"
-
-#define VIRUS_CHECK_DATA_PATH "dev/corpus"
 
 #define COMPRESS_CHECK_MTHREADS 8
 #define COMPRESS_CHECK_ITERATIONS 256

--- a/check/magma/providers/dspam_check.c
+++ b/check/magma/providers/dspam_check.c
@@ -63,7 +63,7 @@ bool_t check_dspam_mail_sthread(void) {
 		}
 
 		// Process the email message.
-		if ((outcome = dspam_check(DSPAM_CHECK_DATA_UNUM, st_char_get(data), &signature)) == -1 || !signature) {
+		if ((outcome = dspam_check(DSPAM_CHECK_DATA_UNUM, data, &signature)) == -1 || !signature) {
 			log_unit("There was a dspam_check error. { message = %i }", i);
 			st_cleanup(signature);
 			st_cleanup(data);

--- a/check/magma/providers/provide_check.c
+++ b/check/magma/providers/provide_check.c
@@ -503,7 +503,7 @@ START_TEST (check_virus_s) {
 	stringer_t *errmsg = NULL;
 
 	if (magma.iface.virus.available) {
-		errmsg = NULLER(check_virus_sthread(virus_check_data_path));
+		errmsg = NULLER(check_virus_sthread());
 	}
 
 	log_test("CHECKERS / VIRUS / SINGLE THREADED:", status() ? errmsg  : NULLER("SKIPPED"));
@@ -518,7 +518,7 @@ START_TEST (check_dspam_mail_s) {
 	bool_t outcome = true;
 	stringer_t *errmsg = NULL;
 
-	if (status() && !check_dspam_mail_sthread(NULL)) {
+	if (status() && !check_dspam_mail_sthread()) {
 		outcome = false;
 		errmsg = NULLER("check_dspam_mail_s failed");
 	}
@@ -534,7 +534,7 @@ START_TEST (check_dspam_bin_s) {
 	bool_t outcome = true;
 	stringer_t *errmsg = NULL;
 
-	if (status() && !check_dspam_binary_sthread(NULL)) {
+	if (status() && !check_dspam_binary_sthread()) {
 		outcome = false;
 		errmsg = NULLER("check_dspam_bin_s failed");
 	}

--- a/check/magma/providers/provide_check.c
+++ b/check/magma/providers/provide_check.c
@@ -520,7 +520,7 @@ START_TEST (check_dspam_mail_s) {
 
 	if (status() && !check_dspam_mail_sthread()) {
 		outcome = false;
-		errmsg = NULLER("check_dspam_mail_s failed");
+		errmsg = NULLER("The check_dspam_mail_s test failed");
 	}
 
 	log_test("CHECKERS / DSPAM / MAIL / SINGLE THREADED:", errmsg);

--- a/check/magma/providers/provide_check.h
+++ b/check/magma/providers/provide_check.h
@@ -35,7 +35,7 @@ stringer_t *  check_rand_sthread(void);
 /// tank_check.c
 bool_t   check_tokyo_tank(check_tank_opt_t *opts);
 bool_t   check_tokyo_tank_cleanup(inx_t *check_collection);
-bool_t   check_tokyo_tank_load(char *location, inx_t *check_collection, check_tank_opt_t *opts);
+bool_t   check_tokyo_tank_load(inx_t *check_collection, check_tank_opt_t *opts);
 bool_t   check_tokyo_tank_mthread(check_tank_opt_t *opts);
 void     check_tokyo_tank_mthread_cnv(check_tank_opt_t *opts);
 bool_t   check_tokyo_tank_sthread(check_tank_opt_t *opts);
@@ -45,14 +45,14 @@ bool_t   check_tokyo_tank_verify(inx_t *check_collection);
 bool_t   check_scramble_sthread(void);
 
 /// dspam_check.c
-bool_t   check_dspam_binary_sthread(chr_t *location);
-bool_t   check_dspam_mail_sthread(chr_t *location);
+bool_t   check_dspam_binary_sthread(void);
+bool_t   check_dspam_mail_sthread(void);
 
 /// provide_check.c
 Suite *      suite_check_provide(void);
 
 /// virus_check.c
-chr_t *  check_virus_sthread(chr_t *location);
+chr_t *  check_virus_sthread(void);
 
 /// ecies_check.c
 void     check_ecies_cleanup(EC_KEY *key, cryptex_t *ciphered, stringer_t *hex_pub, stringer_t *hex_priv, unsigned char *text, unsigned char *copy, unsigned char *original);

--- a/check/magma/providers/virus_check.c
+++ b/check/magma/providers/virus_check.c
@@ -7,88 +7,26 @@
 
 #include "magma_check.h"
 
-chr_t * check_virus_sthread(chr_t *location) {
+chr_t * check_virus_sthread() {
 
-	int fd;
-	DIR *working;
-	chr_t *err = NULL;
-	struct stat info;
-	struct dirent *entry;
-	char file[1024], *buffer;
+	stringer_t *data = NULL;
+	uint32_t max = check_message_max();
 
-	if (!(working = opendir(location))) {
-		return "Unable to open the data path";
+	for (uint32_t i = 0; i < max && status(); i++) {
+
+		// Retrieve data for the current message.
+		if (!(data = check_message_get(i))) {
+			log_info("Failed to get the message data. { message = %i }", i);
+			return "check_message_get() error";
+		}
+
+		if (virus_check(data) == -1) {
+			log_info("There was a virus check error. { message = %i }", i);
+			return "virus check error";
+		}
+
+		st_cleanup(data);
 	}
 
-	while (status() && (entry = readdir(working))) {
-
-		// Reset.
-		errno = 0;
-		bzero(file, 1024);
-		bzero(&info, sizeof(struct stat));
-
-		// Build an absolute path.
-		snprintf(file, 1024, "%s%s%s", location, "/", entry->d_name);
-
-		// If we hit a directory, recursively call the load function.
-		if (entry->d_type == DT_DIR && *(entry->d_name) != '.') {
-			if ((err = check_virus_sthread(file))) {
-				return err;
-			}
-		}
-		// Otherwise if its a regular file try storing it.
-		else if (entry->d_type == DT_REG && *(entry->d_name) != '.') {
-
-			// Read the file.
-			if ((fd = open(file, O_RDONLY)) < 0) {
-				log_info("%s - open error", file);
-				closedir(working);
-				return "open error";
-			}
-
-			// How big is the file?
-			if (fstat(fd, &info) != 0) {
-				log_info("%s - stat error", file);
-				closedir(working);
-				close(fd);
-				return "stat error";
-			}
-
-			// Allocate a buffer.
-			if (!(buffer = mm_alloc(info.st_size + 1))) {
-				log_info("%s - malloc error", file);
-				closedir(working);
-				close(fd);
-				return "malloc error";
-			}
-
-			// Clear the buffer.
-			memset(buffer, 0, info.st_size + 1);
-
-			// Read the file.
-			if (read(fd, buffer, info.st_size) != info.st_size) {
-				log_info("%s - read error", file);
-				closedir(working);
-				mm_free(buffer);
-				close(fd);
-				return "read error";
-			}
-
-			close(fd);
-
-			if (virus_check(PLACER(buffer, info.st_size)) == -1) {
-				log_info("%s - virus check error", file);
-				closedir(working);
-				mm_free(buffer);
-				close(fd);
-				return "virus check error";
-			}
-
-			mm_free(buffer);
-			close(fd);
-		}
-	}
-
-	closedir(working);
 	return NULL;
 }

--- a/check/magma/providers/virus_check.c
+++ b/check/magma/providers/virus_check.c
@@ -7,7 +7,7 @@
 
 #include "magma_check.h"
 
-chr_t * check_virus_sthread() {
+chr_t * check_virus_sthread(void) {
 
 	stringer_t *data = NULL;
 	uint32_t max = check_message_max();


### PR DESCRIPTION
Refactored the following tests to follow the new paradigm for accessing the test corpus (i.e. check_message_* functions):
- **check_dspam_mail_s**
- **check_virus_s**
- **check_tank_***

also removed defines for the directory path from **magma_check.h**