### PR TITLE
Feature/inx append test

### DIFF
--- a/check/magma/core/core_check.c
+++ b/check/magma/core/core_check.c
@@ -340,6 +340,37 @@ START_TEST (check_inx_hashed_cursor_m) {
 }
 END_TEST
 
+START_TEST (check_inx_append_s) {
+
+	log_disable();
+	bool_t outcome = true;
+	char *errmsg = NULL;
+
+	outcome = check_inx_append_sthread(M_INX_TREE, &errmsg);
+	if (outcome) outcome = check_inx_append_sthread(M_INX_HASHED, &errmsg);
+	if (outcome) outcome = check_inx_append_sthread(M_INX_LINKED, &errmsg);
+
+	log_test("CORE / INDEX / APPEND / SINGLE THREADED:", NULLER(errmsg));
+	ck_assert_msg(outcome, errmsg);
+}
+END_TEST
+
+
+START_TEST (check_inx_append_m) {
+
+	log_disable();
+	bool_t outcome = true;
+	char *errmsg = NULL;
+
+	outcome = check_inx_append_mthread(M_INX_TREE, &errmsg);
+	if (outcome) outcome = check_inx_append_mthread(M_INX_HASHED, &errmsg);
+	if (outcome) outcome = check_inx_append_mthread(M_INX_LINKED, &errmsg);
+
+	log_test("CORE / INDEX / APPEND / MULTI THREADED:", NULLER("SKIPPED"));
+	ck_assert_msg(outcome, errmsg);
+}
+END_TEST
+
 START_TEST (check_constants) {
 
 	log_disable();
@@ -884,6 +915,8 @@ Suite * suite_check_core(void) {
 	testcase(s, tc, "Indexes / Hashed Cursor/M", check_inx_hashed_cursor_m);
 	testcase(s, tc, "Indexes / Tree Cursor/S", check_inx_tree_cursor_s);
 	testcase(s, tc, "Indexes / Tree Cursor/M", check_inx_tree_cursor_m);
+	testcase(s, tc, "Indexes / Append /S", check_inx_append_s);
+	testcase(s, tc, "Indexes / Append /M", check_inx_append_m);
 
 	return s;
 }

--- a/check/magma/core/core_check.c
+++ b/check/magma/core/core_check.c
@@ -132,7 +132,7 @@ START_TEST (check_inx_linked_m) {
 		mm_free(opts);
 	}
 
-	log_test("CORE / INDEX / LINKED / MULTITHREADED:", errmsg);
+	log_test("CORE / INDEX / LINKED / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 }
 END_TEST
@@ -172,7 +172,7 @@ START_TEST (check_inx_tree_m) {
 		mm_free(opts);
 	}
 
-	log_test("CORE / INDEX / TREE / MULTITHREADED:", errmsg);
+	log_test("CORE / INDEX / TREE / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 }
 END_TEST
@@ -213,7 +213,7 @@ START_TEST (check_inx_hashed_m) {
 		mm_free(opts);
 	}
 
-	log_test("CORE / INDEX / HASHED / MULTITHREADED:", errmsg);
+	log_test("CORE / INDEX / HASHED / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 }
 END_TEST
@@ -253,7 +253,7 @@ START_TEST (check_inx_linked_cursor_m) {
 		mm_free(opts);
 	}
 
-	log_test("CORE / INDEX / LINKED CURSOR / MULTITHREADED:", NULLER(errmsg));
+	log_test("CORE / INDEX / LINKED CURSOR / MULTI THREADED:", NULLER(errmsg));
 	ck_assert_msg(outcome, errmsg);
 }
 END_TEST
@@ -294,7 +294,7 @@ START_TEST (check_inx_tree_cursor_m) {
 		mm_free(opts);
 	}
 
-	log_test("CORE / INDEX / TREE CURSOR / MULTITHREADED:", errmsg);
+	log_test("CORE / INDEX / TREE CURSOR / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 }
 END_TEST
@@ -335,7 +335,7 @@ START_TEST (check_inx_hashed_cursor_m) {
 		mm_free(opts);
 	}
 
-	log_test("CORE / INDEX / HASHED CURSOR / MULTITHREADED:", errmsg);
+	log_test("CORE / INDEX / HASHED CURSOR / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 }
 END_TEST
@@ -480,7 +480,7 @@ START_TEST (check_digits) {
 	uint64_t ui64;
 
 	char buf[1024];
-	stringer_t *errmsg;
+	stringer_t *errmsg = NULL;
 	bool_t outcome = true;
 
 	for (uint64_t i = 0; status() && outcome && i < 8192; i++) {

--- a/check/magma/core/core_check.c
+++ b/check/magma/core/core_check.c
@@ -344,13 +344,13 @@ START_TEST (check_inx_append_s) {
 
 	log_disable();
 	bool_t outcome = true;
-	char *errmsg = NULL;
+	stringer_t *errmsg = NULL;
 
-	outcome = check_inx_append_sthread(M_INX_TREE, &errmsg);
-	if (outcome) outcome = check_inx_append_sthread(M_INX_HASHED, &errmsg);
-	if (outcome) outcome = check_inx_append_sthread(M_INX_LINKED, &errmsg);
+	outcome = check_inx_append_sthread(M_INX_TREE, errmsg);
+	if (outcome) outcome = check_inx_append_sthread(M_INX_HASHED, errmsg);
+	if (outcome) outcome = check_inx_append_sthread(M_INX_LINKED, errmsg);
 
-	log_test("CORE / INDEX / APPEND / SINGLE THREADED:", NULLER(errmsg));
+	log_test("CORE / INDEX / APPEND / SINGLE THREADED:", errmsg);
 	ck_assert_msg(outcome, errmsg);
 }
 END_TEST
@@ -360,7 +360,7 @@ START_TEST (check_inx_append_m) {
 
 	log_disable();
 	bool_t outcome = true;
-	char *errmsg = NULL;
+	stringer_t *errmsg = NULL;
 
 	outcome = check_inx_append_mthread(M_INX_TREE, &errmsg);
 	if (outcome) outcome = check_inx_append_mthread(M_INX_HASHED, &errmsg);
@@ -915,8 +915,8 @@ Suite * suite_check_core(void) {
 	testcase(s, tc, "Indexes / Hashed Cursor/M", check_inx_hashed_cursor_m);
 	testcase(s, tc, "Indexes / Tree Cursor/S", check_inx_tree_cursor_s);
 	testcase(s, tc, "Indexes / Tree Cursor/M", check_inx_tree_cursor_m);
-	testcase(s, tc, "Indexes / Append /S", check_inx_append_s);
-	testcase(s, tc, "Indexes / Append /M", check_inx_append_m);
+	testcase(s, tc, "Indexes / Append/S", check_inx_append_s);
+	testcase(s, tc, "Indexes / Append/M", check_inx_append_m);
 
 	return s;
 }

--- a/check/magma/core/core_check.h
+++ b/check/magma/core/core_check.h
@@ -46,6 +46,8 @@ bool_t    check_inx_cursor_sthread(check_inx_opt_t *opts);
 bool_t    check_inx_mthread(check_inx_opt_t *opts);
 void		  check_inx_mthread_cnv(check_inx_opt_t *opts);
 bool_t    check_inx_sthread(check_inx_opt_t *opts);
+bool_t 	  check_inx_append_sthread(MAGMA_INDEX, stringer_t*);
+bool_t 	  check_inx_append_mthread(MAGMA_INDEX, stringer_t*);
 
 /// linked_check.c
 bool_t   check_indexes_linked_cursor(char **errmsg);

--- a/check/magma/core/inx_check.c
+++ b/check/magma/core/inx_check.c
@@ -215,7 +215,7 @@ bool_t check_inx_append_sthread(MAGMA_INDEX inx_type, stringer_t *errmsg) {
 				}
 				last_key = key;
 			} else if (i % 2 == 0) {
-				if (!inx_insert(opts->inx, key, val)) {
+				if (!inx_append(opts->inx, key, val)) {
 					errmsg = NULLER("An error occured during inx_append");
 					mm_free(val);
 					outcome = false;
@@ -236,7 +236,7 @@ bool_t check_inx_append_sthread(MAGMA_INDEX inx_type, stringer_t *errmsg) {
 		}
 	}
 
-	if (!inx_count(opts->inx)) {
+	if (inx_count(opts->inx) != 0) {
 		outcome = false;
 		errmsg = NULLER("The index was not properly cleared.");
 	}

--- a/check/magma/magma_check.c
+++ b/check/magma/magma_check.c
@@ -298,6 +298,7 @@ int main(int argc, char *argv[]) {
 		srunner_add_suite(sr, suite_check_users());
 		srunner_add_suite(sr, suite_check_mail());
 		srunner_add_suite(sr, suite_check_smtp());
+		srunner_add_suite(sr, suite_check_regression());
 	}
 
 	// If were being run under Valgrind, we need to disable forking and increase the default timeout.

--- a/check/magma/magma_check.h
+++ b/check/magma/magma_check.h
@@ -32,6 +32,7 @@
 #include "users/users_check.h"
 #include "mail/mail_check.h"
 #include "smtp/smtp_check.h"
+#include "regression/regression_check.h"
 
 extern int case_timeout;
 
@@ -118,6 +119,8 @@ Suite * suite_check_sample(void);
 
 #define OBJECT_CHECK_ITERATIONS 16
 
+#define REGRESSION_CHECK_FILE_DESCRIPTORS_LEAK_MTHREADS 8
+
 //! Exhaustive Test
 #else
 
@@ -201,5 +204,7 @@ Suite * suite_check_sample(void);
 //#define SYMMETRIC_CHECK_SIZE_MAX (1 * 1024 * 1024) // 1 megabyte
 
 #define OBJECT_CHECK_ITERATIONS 256
+
+#define REGRESSION_CHECK_FILE_DESCRIPTORS_LEAK_MTHREADS 32
 
 #endif

--- a/check/magma/providers/provide_check.c
+++ b/check/magma/providers/provide_check.c
@@ -76,7 +76,7 @@ START_TEST (check_compress_lzo_m) {
 		errmsg = NULLER("The multi-threaded LZO compression test failed.");
 	}
 
-	log_test("COMPRESSION / LZO / MULTITHREADED:", errmsg);
+	log_test("COMPRESSION / LZO / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 }
 END_TEST
@@ -114,7 +114,7 @@ START_TEST (check_compress_zlib_m) {
 		errmsg = NULLER("The multi-threaded ZLIB compression test failed.");
 	}
 
-	log_test("COMPRESSION / ZLIB / MULTITHREADED:", errmsg);
+	log_test("COMPRESSION / ZLIB / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 }
 END_TEST
@@ -152,7 +152,7 @@ START_TEST (check_compress_bzip_m) {
 		errmsg = NULLER("The multi-threaded BZIP compression test failed.");
 	}
 
-	log_test("COMPRESSION / BZIP / MULTITHREADED:", errmsg);
+	log_test("COMPRESSION / BZIP / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 }
 END_TEST
@@ -192,7 +192,7 @@ START_TEST (check_tank_lzo_m) {
 		errmsg = NULLER("The multi-threaded LZO storage tank test failed.");
 	}
 
-	log_test("TANK / LZO / MULTITHREADED:", errmsg);
+	log_test("TANK / LZO / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 	tank_maintain();
 }
@@ -233,7 +233,7 @@ START_TEST (check_tank_zlib_m) {
 		errmsg = NULLER("The multi-threaded ZLIB storage tank test failed.");
 	}
 
-	log_test("TANK / ZLIB / MULTITHREADED:", errmsg);
+	log_test("TANK / ZLIB / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 	tank_maintain();
 }
@@ -273,7 +273,7 @@ START_TEST (check_tank_bzip_m) {
 		errmsg = NULLER("The multi-threaded BZIP storage tank test failed.");
 	}
 
-	log_test("TANK / BZIP / MULTITHREADED:", errmsg);
+	log_test("TANK / BZIP / MULTI THREADED:", errmsg);
 	ck_assert_msg(outcome, st_char_get(errmsg));
 	tank_maintain();
 
@@ -426,7 +426,7 @@ START_TEST (check_rand_m) {
 
 	errmsg = check_rand_mthread();
 
-	log_test("CRYPTOGRAPHY / RAND / MULTITHREADED:", errmsg);
+	log_test("CRYPTOGRAPHY / RAND / MULTI THREADED:", errmsg);
 	ck_assert_msg(!errmsg, st_char_get(errmsg));
 	st_cleanup(errmsg);
 }

--- a/check/magma/regression/regression_check.c
+++ b/check/magma/regression/regression_check.c
@@ -7,9 +7,13 @@
 #include "magma_check.h"
 
 bool_t check_regression_file_descriptors_leak_mthread(void) {
-	stringer_t *m = st_alloc_opts(MAPPED_T | JOINTED | HEAP, 1024);
-	st_free(m);
-	return true;
+	stringer_t *m;
+	if (!(m = st_alloc_opts(MAPPED_T | JOINTED | HEAP, 1024))) {
+		return false;
+	} else {
+		st_free(m);
+		return true;
+	}
 }
 
 START_TEST (check_regression_file_descriptors_leak_m) {

--- a/check/magma/regression/regression_check.c
+++ b/check/magma/regression/regression_check.c
@@ -1,0 +1,73 @@
+/**
+ * @file /check/magma/regression/regression_check.c
+ *
+ * @brief The heart of the regression test suite
+ */
+
+#include "magma_check.h"
+
+bool_t check_regression_file_descriptors_leak_mthread(void) {
+	stringer_t *m = st_alloc_opts(MAPPED_T | JOINTED | HEAP, 1024);
+	st_free(m);
+	return true;
+}
+
+START_TEST (check_regression_file_descriptors_leak_m) {
+
+	log_disable();
+	void *result = NULL;
+	bool_t outcome = true;
+	pthread_t *threads = NULL;
+	stringer_t *errmsg = NULL, *path = NULL;
+	int_t folders_before, folder_difference = 0;
+
+	if (!(threads = mm_alloc(sizeof(pthread_t) * REGRESSION_CHECK_FILE_DESCRIPTORS_LEAK_MTHREADS))) {
+		errmsg = NULLER("Thread allocation failed.");
+		outcome = false;
+	} else {
+		path = st_quick(MANAGEDBUF(255), "/proc/%i/fd/", process_my_pid());
+		folders_before = folder_count(path, false, false);
+
+		// fork a bunch of processes that open file descriptors
+		for (uint64_t counter = 0; counter < REGRESSION_CHECK_FILE_DESCRIPTORS_LEAK_MTHREADS; counter++) {
+			if (thread_launch(threads + counter, &check_regression_file_descriptors_leak_mthread, NULL)) {
+				errmsg = NULLER("Thread launch failed.");
+				outcome = false;
+			}
+		}
+
+		// join them, each process should handle its own cleanup
+		for (uint64_t counter = 0; counter < REGRESSION_CHECK_FILE_DESCRIPTORS_LEAK_MTHREADS; counter++) {
+			if (thread_result(*(threads + counter), &result)) {
+				if (!errmsg) errmsg = NULLER("Thread join error.");
+				outcome = false;
+			}
+			else if (!result) {
+				if (!errmsg) errmsg = NULLER("Thread test failed.");
+				outcome = false;
+			}
+		}
+
+		folder_difference = folder_count(path, false, false) - folders_before;
+
+		if (folder_difference) {
+			outcome = false;
+			errmsg = NULLER("Failed to properly clean file handles.");
+		}
+	}
+
+	log_test("REGRESSION / FILE DESCRIPTORS LEAK / MULTI THREADED:", errmsg);
+	ck_assert_msg(outcome, st_char_get(errmsg));
+	mm_free(threads);
+}
+END_TEST
+
+Suite * suite_check_regression(void) {
+	TCase *tc;
+	Suite *s = suite_create("\tRegression");
+
+	testcase(s, tc, "Regression File Descriptors Leak/M", check_regression_file_descriptors_leak_m);
+
+	tcase_set_timeout(tc, 120);
+	return s;
+}

--- a/check/magma/regression/regression_check.h
+++ b/check/magma/regression/regression_check.h
@@ -1,0 +1,14 @@
+/**
+ * @file /check/magma/regression/regression_check.h
+ *
+ * @brief Regression unit tests
+ */
+
+#ifndef REGRESSION_CHECK_H
+#define REGRESSION_CHECK_H
+
+/// regression_check.c
+bool_t check_regression_file_descriptors_leak_mthread(void);
+Suite * suite_check_regression(void);
+
+#endif

--- a/dev/scripts/launch/check.vg.sh
+++ b/dev/scripts/launch/check.vg.sh
@@ -14,7 +14,7 @@ MAGMA_DIST=`pwd`
 
 # add for suppressions --gen-suppressions=all
 # self modifying code --smc-check=[none,stack,all]
-#
+# track file descriptors --track-fds=yes
 
 valgrind --tool=memcheck \
 --trace-children=yes \
@@ -30,7 +30,6 @@ valgrind --tool=memcheck \
 --smc-check=none \
 --fullpath-after= \
 --leak-check=yes \
---track-fds=yes \
 --show-reachable=yes \
 --leak-resolution=high \
 --workaround-gcc296-bugs=no \

--- a/dev/scripts/launch/magma.vg.sh
+++ b/dev/scripts/launch/magma.vg.sh
@@ -14,6 +14,7 @@ MAGMA_DIST=`pwd`
 
 # add for suppressions --gen-suppressions=all
 # self modifying code --smc-check=[none,stack,all]
+# track file descriptors --track-fds=yes
 
 valgrind --tool=memcheck \
 --trace-children=yes \
@@ -29,7 +30,6 @@ valgrind --tool=memcheck \
 --smc-check=none \
 --fullpath-after= \
 --leak-check=yes \
---track-fds=yes \
 --show-reachable=yes \
 --leak-resolution=high \
 --workaround-gcc296-bugs=no \

--- a/src/engine/context/signal.c
+++ b/src/engine/context/signal.c
@@ -187,17 +187,17 @@ void signal_refresh(int signal) {
  */
 bool_t signal_thread_start(void) {
 
-//	struct sigaction status;
-//
-//	/// TODO: Disabling this signal handler to see if it fixes the shutdown issue.
-//	// Zero out the signal structure and setup the normal shutdown handler.
-//	mm_wipe(&status, sizeof(struct sigaction));
-//	status.sa_handler = signal_status;
-//	status.sa_flags = 0;
-//	if (sigemptyset(&status.sa_mask) || sigaction(SIGALRM, &status, NULL)) {
-//		log_info("Could not setup the thread status signal handler.");
-//		return false;
-//	}
+	struct sigaction status;
+
+	/// TODO: Disabling this signal handler to see if it fixes the shutdown issue.
+	// Zero out the signal structure and setup the normal shutdown handler.
+	mm_wipe(&status, sizeof(struct sigaction));
+	status.sa_handler = signal_status;
+	status.sa_flags = 0;
+	if (sigemptyset(&status.sa_mask) || sigaction(SIGALRM, &status, NULL)) {
+		log_info("Could not setup the thread status signal handler.");
+		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
- Added a regression test suite with one test for detecting file descriptor leaks
- Removed the trackfds option from the check.vg.sh and magma.vg.sh scripts
- Added a single-threaded test for inx_append that's generic across the data structure used
- Reverted a lot of "MULTITHREADED" to "MULTI THREADED"
- Fixed a small allocation error in core_check.c 